### PR TITLE
Most basic d3 example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ WORKDIR /music-box-interactive-client/generator
 
 # install site dependencies and build
 RUN npm install --legacy-peer-deps
+RUN npm install d3 --legacy-peer-deps
 RUN gatsby build

--- a/generator/package.json
+++ b/generator/package.json
@@ -19,6 +19,7 @@
     "@storybook/addon-outline": "^6.5.16",
     "axios": "^1.3.5",
     "bootstrap": "^5.2.0",
+    "d3": "^7.8.5",
     "gatsby": "^4.18.2",
     "lodash": "^4.17.21",
     "open-iconic": "^1.1.1",

--- a/generator/src/components/Layout.js
+++ b/generator/src/components/Layout.js
@@ -89,6 +89,10 @@ function Layout(props) {
                                         <span className="oi oi-fork oi-prefix"></span>
                                         Flow Diagram
                                     </Link>
+                                    <Link className="nav-link" to="/d3_flow" activeStyle={activeColor}>
+                                        <span className="oi oi-fork oi-prefix"></span>
+                                        d3_flow
+                                    </Link>
                                     <Link className="nav-link" to="/downloads" activeStyle={activeColor}>
                                         <span className="oi oi-data-transfer-download oi-prefix"></span>
                                         Download

--- a/generator/src/pages/d3_flow.js
+++ b/generator/src/pages/d3_flow.js
@@ -1,0 +1,119 @@
+
+import * as d3 from "d3";
+import { connect } from "react-redux";
+import React, { useEffect, useMemo, useState } from "react";
+import Layout from "../components/Layout";
+import {
+    getRunStatus,
+    getMechanism,
+    getPlots,
+    getSpeciesPlots,
+    getReactionPlots,
+    getEnvironmentPlots
+} from "../redux/selectors";
+import { RunStatus } from "../controllers/models";
+import debounce from 'lodash/debounce';
+import { fetchFlowDiagram } from "../controllers/api"
+import { translate_reactions_to_camp_config } from "../controllers/transformers"
+import legend from "../assets/plot_diagram_legend.png"
+import Dropdown from 'react-bootstrap/Dropdown'
+import Button from 'react-bootstrap/Button';
+import { plotSpeciesUnits } from "../redux/schemas";
+
+
+import { Container, Row, Col, Form, ListGroup } from 'react-bootstrap';
+import DropdownMenu from "react-bootstrap/esm/DropdownMenu";
+
+
+function ForceGraph({ nodes, charge }) {
+    const [animatedNodes, setAnimatedNodes] = useState([]);
+
+    // re-create animation every time nodes change
+    useEffect(() => {
+        const simulation = d3
+            .forceSimulation()
+            .force("x", d3.forceX(400))
+            .force("y", d3.forceY(300))
+            .force("charge", d3.forceManyBody().strength(charge))
+            .force("collision", d3.forceCollide(5));
+
+        // update state on every frame
+        simulation.on("tick", () => {
+            setAnimatedNodes([...simulation.nodes()]);
+        });
+
+        // copy nodes into simulation
+        simulation.nodes([...nodes]);
+        // slow down with a small alpha
+        simulation.alpha(0.1).restart();
+
+        // stop simulation on unmount
+        return () => simulation.stop();
+    }, [nodes, charge]);
+
+    return (
+        <g>
+            {animatedNodes.map((node) => (
+                <circle
+                    cx={node.x}
+                    cy={node.y}
+                    r={node.r}
+                    key={node.id}
+                    stroke="black"
+                    fill="transparent"
+                />
+            ))}
+        </g>
+    );
+}
+
+const mapStateToProps = state => {
+    return {
+        runStatus: getRunStatus(state),
+        mechanism: getMechanism(state),
+        plots: getPlots(state),
+        speciesPlots: getSpeciesPlots(state),
+        reactionPlots: getReactionPlots(state),
+        environmentPlots: getEnvironmentPlots(state)
+    }
+}
+
+function NetworkGraph() {
+    const [charge, setCharge] = useState(-3);
+
+    // create nodes with unique ids
+    // radius: 5px
+    const nodes = useMemo(
+        () =>
+            d3.range(50).map((n) => {
+                return { id: n, r: 5 };
+            }),
+        []
+    );
+
+    return (
+        <Layout>
+            <main role="main" style={{ padding: `1em` }}>
+                <div className="NetworkGraph">
+                    <h1>React & D3 force graph</h1>
+                    <p>Current charge: {charge}</p>
+                    <input
+                        type="range"
+                        min="-30"
+                        max="30"
+                        step="1"
+                        value={charge}
+                        onChange={(e) => setCharge(e.target.value)}
+                    />
+                    <svg width="800" height="600">
+                        <ForceGraph nodes={nodes} charge={charge} />
+                    </svg>
+                </div>
+            </main>
+        </Layout>
+
+    );
+}
+
+
+export default connect(mapStateToProps)(NetworkGraph)


### PR DESCRIPTION
A simple d3 example, the d3 enabled page is called "d3_flow" and has a super basic general diagram to show that d3 is working. Requires pr on api side to run.