### PR TITLE
Fix id used to find rate constant conditions

### DIFF
--- a/src/components/Conditions/ReactionCondition.jsx
+++ b/src/components/Conditions/ReactionCondition.jsx
@@ -97,11 +97,13 @@ const ReactionCondition = (props) => {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const condition = getConditions(state, ownProps.schema)[ownProps.conditionId];
+  const condition = getConditions(state, ownProps.schema).filter((condition) => {
+    return condition.id === ownProps.conditionId;
+  })[0];
   return {
     condition: condition,
     reactionNames: getUserDefinedRates(state),
-    possibleUnits: getPossibleUnits(state, condition.name),
+    possibleUnits: getPossibleUnits(state, condition?.name),
   };
 };
 


### PR DESCRIPTION
Fixes a bug that prevented rate constant initial conditions from being displayed properly. The original code was using the index of the element in the array of rate constant conditions, rather than the id field in the array element object. These are the same until an array element is deleted, but afterwards they differ