### PR TITLE
Connecting reaction to conditions so musica name changes propogate

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-router": "^6.20.1",
     "react-router-dom": "^6.20.1",
     "redux": "^5.0.0",
-    "redux-thunk": "^3.1.0"
+    "redux-thunk": "^3.1.0",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.37",

--- a/src/components/Conditions/ReactionCondition.jsx
+++ b/src/components/Conditions/ReactionCondition.jsx
@@ -10,16 +10,11 @@ import {
   getUserDefinedRatesIds,
   getPossibleUnits,
 } from "../../redux/selectors";
-import { cond } from "lodash";
 
 const ReactionCondition = (props) => {
   const condition = props.condition;
   const schema = props.schema;
-  const name = condition.reactionId ? "asdf" : null;
-  if (condition.reactionId) {
-    console.log(getReaction(condition.reactionId))
-  }
-  console.log(condition.reactionId)
+  const name = condition.reactionId ? props.reactionNames.find((reaction) => reaction.id === condition.reactionId).name : null;
 
   const handleUpdate = (newProps) => {
     props.addCondition({
@@ -41,7 +36,6 @@ const ReactionCondition = (props) => {
           <Dropdown.Menu>
             {schema.allowAddRemove
               ? props.reactionNames.map((value, index) => {
-                  console.log(value.name, name)
                   return (
                     <Dropdown.Item
                       href="#"
@@ -103,7 +97,6 @@ const ReactionCondition = (props) => {
 
 const mapStateToProps = (state, ownProps) => {
   const condition = getConditions(state, ownProps.schema).find(condition => condition.id === ownProps.conditionId)
-  console.log(condition)
   return {
     condition: condition,
     reactionNames: getUserDefinedRatesIds(state),

--- a/src/components/Conditions/ReactionCondition.jsx
+++ b/src/components/Conditions/ReactionCondition.jsx
@@ -6,12 +6,20 @@ import RemoveCondition from "./RemoveCondition";
 import {
   getConditions,
   getUserDefinedRates,
+  getReaction,
+  getUserDefinedRatesIds,
   getPossibleUnits,
 } from "../../redux/selectors";
+import { cond } from "lodash";
 
 const ReactionCondition = (props) => {
   const condition = props.condition;
   const schema = props.schema;
+  const name = condition.reactionId ? "asdf" : null;
+  if (condition.reactionId) {
+    console.log(getReaction(condition.reactionId))
+  }
+  console.log(condition.reactionId)
 
   const handleUpdate = (newProps) => {
     props.addCondition({
@@ -28,26 +36,25 @@ const ReactionCondition = (props) => {
       <div className="col-5">
         <Dropdown>
           <Dropdown.Toggle variant="success" className="btn btn-light">
-            {condition.name && condition.name.length
-              ? condition.name
-              : "<select>"}
+            {name || "<select>"}
           </Dropdown.Toggle>
           <Dropdown.Menu>
             {schema.allowAddRemove
-              ? props.reactionNames.map((value) => {
+              ? props.reactionNames.map((value, index) => {
+                  console.log(value.name, name)
                   return (
                     <Dropdown.Item
                       href="#"
-                      key={value.name}
+                      key={index}
                       onClick={() => {
-                        handleUpdate({ name: value.name, type: value.prefix });
+                        handleUpdate({ reactionId: value.id, type: value.prefix });
                       }}
                     >
                       {value.name}
                     </Dropdown.Item>
                   );
                 })
-              : condition.name}
+              : name}
           </Dropdown.Menu>
         </Dropdown>
       </div>
@@ -64,9 +71,7 @@ const ReactionCondition = (props) => {
       <div className="col-3">
         <Dropdown>
           <Dropdown.Toggle variant="success" className="btn btn-light">
-            {condition.units && condition.units.length
-              ? condition.units
-              : "<select>"}
+            {condition.units || "<select>"}
           </Dropdown.Toggle>
           <Dropdown.Menu>
             {props.possibleUnits && props.possibleUnits.length
@@ -97,11 +102,12 @@ const ReactionCondition = (props) => {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const condition = getConditions(state, ownProps.schema)[ownProps.conditionId];
+  const condition = getConditions(state, ownProps.schema).find(condition => condition.id === ownProps.conditionId)
+  console.log(condition)
   return {
     condition: condition,
-    reactionNames: getUserDefinedRates(state),
-    possibleUnits: getPossibleUnits(state, condition.name),
+    reactionNames: getUserDefinedRatesIds(state),
+    possibleUnits: getPossibleUnits(state, condition.reactionId),
   };
 };
 

--- a/src/redux/reducers/conditions.js
+++ b/src/redux/reducers/conditions.js
@@ -62,7 +62,6 @@ export const conditionsReducer = (state = initialState, action) => {
     }
     case utils.action_types.ADD_CONDITION: {
       const schema = action.payload.content.schema;
-      console.log(schema)
       const condition =
         action.payload.content.condition !== undefined
           ? action.payload.content.condition

--- a/src/redux/reducers/conditions.js
+++ b/src/redux/reducers/conditions.js
@@ -1,5 +1,6 @@
 import utils from "../utils";
 import { extract_conditions_from_example } from "../../controllers/transformers";
+import { v4 as uuidv4 } from 'uuid';
 
 const initialState = {
   basic: {
@@ -61,16 +62,12 @@ export const conditionsReducer = (state = initialState, action) => {
     }
     case utils.action_types.ADD_CONDITION: {
       const schema = action.payload.content.schema;
+      console.log(schema)
       const condition =
         action.payload.content.condition !== undefined
           ? action.payload.content.condition
-          : { name: undefined, value: undefined, units: undefined };
-      const conditionId =
-        "id" in condition
-          ? condition.id
-          : state[schema.classKey].length > 0
-            ? Math.max(...state[schema.classKey].map((c) => c.id)) + 1
-            : 0;
+          : { reactionId: undefined, value: undefined, units: undefined };
+      const conditionId = condition.id || uuidv4();
       const otherConditions = state[schema.classKey].filter((condition) => {
         return condition.id !== conditionId;
       });

--- a/src/redux/reducers/mechanism.js
+++ b/src/redux/reducers/mechanism.js
@@ -1,5 +1,6 @@
 import utils from "../utils";
 import { extract_mechanism_from_example } from "../../controllers/transformers";
+import { v4 as uuidv4 } from 'uuid';
 
 const initialState = {
   gasSpecies: [{ name: "M", properties: [], static: true }],
@@ -131,12 +132,7 @@ export const mechanismReducer = (state = initialState, action) => {
     }
     case utils.action_types.ADD_REACTION: {
       const reaction = action.payload.content;
-      const id =
-        "id" in reaction
-          ? reaction.id
-          : state.reactions.length > 0
-            ? Math.max(...state.reactions.map((r) => r.id)) + 1
-            : 0;
+      const id = reaction.id || uuidv4();
       const otherReactions = state.reactions.filter((reaction) => {
         return reaction.id !== id;
       });

--- a/src/redux/selectors/conditions.js
+++ b/src/redux/selectors/conditions.js
@@ -1,5 +1,6 @@
-export const getConditions = (store, schema) =>
-  store.conditions[schema.classKey];
+export const getConditions = (store, schema) => {
+  return store.conditions[schema.classKey];
+}
 
 export const getEvolvingConditions = (store) => store.conditions.evolving;
 

--- a/src/redux/selectors/mechanism.js
+++ b/src/redux/selectors/mechanism.js
@@ -43,6 +43,7 @@ export const getProperty = (store, speciesName) => {
 };
 
 export const getReaction = (store, reactionId) => {
+  console.log(getMechanism(store))
   const reaction = getMechanism(store).reactions.filter((reaction) => {
     return reaction.id === reactionId;
   });
@@ -80,10 +81,47 @@ export const getUserDefinedRates = (store) => {
     });
 };
 
-export const getPossibleUnits = (store, musicaName) => {
+const reactionToLabel = (reaction) => {
+  let name = '';
+  switch(reaction.type) {
+    case "PHOTOLYSIS":
+      name = reaction.reactant + "->";
+      name += reaction.products.map(item => item.name).join('+');
+      break;
+    case "EMISSION":
+      name = "->" + reaction.species;
+      break;
+    case "FIRST_ORDER_LOSS":
+      name = reaction.species + "->";
+      break;
+    default:
+      name = reaction.reactants.map(item => item.name).join('+') + "->";
+      name += reaction.products.map(item => item.name).join('+');
+      break;
+  }
+  return name;
+}
+
+export const getUserDefinedRatesIds = (store) => {
   return getMechanism(store)
     .reactions.filter((reaction) => {
-      return reaction.data.musica_name === musicaName;
+      return (
+        reaction.isUserDefined
+      );
+    })
+    .map((reaction) => {
+      return {
+        id: reaction.id,
+        name: reaction.data.musica_name || reactionToLabel(reaction.data),
+        prefix: reaction.tablePrefix,
+      };
+    });
+};
+
+export const getPossibleUnits = (store, reactionId) => {
+  return getMechanism(store)
+    .reactions.filter((reaction) => {
+      return reaction.data.id === reactionId;
     })
     .map((reaction) => {
       return reaction.possibleUnits;

--- a/src/redux/selectors/mechanism.js
+++ b/src/redux/selectors/mechanism.js
@@ -43,7 +43,6 @@ export const getProperty = (store, speciesName) => {
 };
 
 export const getReaction = (store, reactionId) => {
-  console.log(getMechanism(store))
   const reaction = getMechanism(store).reactions.filter((reaction) => {
     return reaction.id === reactionId;
   });
@@ -121,7 +120,7 @@ export const getUserDefinedRatesIds = (store) => {
 export const getPossibleUnits = (store, reactionId) => {
   return getMechanism(store)
     .reactions.filter((reaction) => {
-      return reaction.data.id === reactionId;
+      return reaction.id === reactionId;
     })
     .map((reaction) => {
       return reaction.possibleUnits;

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,9 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react()
+  ],
   css: {
     modules: true,
   },


### PR DESCRIPTION
Closes #120 and closes #119

- For reactions without a musica name, a name is formed using the products/reactants 
- Uses uuid for the reaction and conditions ids
- Conditions now store reaction ids
- The reaction name is now looked up by id