### PR TITLE
separating tooltip drawing so that many plots don't lag

### DIFF
--- a/src/components/Plots/LinePlot.jsx
+++ b/src/components/Plots/LinePlot.jsx
@@ -169,6 +169,11 @@ const LinePlot = ({
       tooltipGroupRef.current.style("opacity", 1);
       dotRef.current.style("opacity", 1);
     };
+    const hideToolTip = () => {
+      verticalLineRef.current.style("opacity", 0);
+      tooltipGroupRef.current.style("opacity", 0);
+      dotRef.current.style("opacity", 0);
+    }
 
     const updateTooltip = (index) => {
       const activeData = data[index];
@@ -192,9 +197,7 @@ const LinePlot = ({
         showToolTip();
       })
       .on("mouseleave", () => {
-        verticalLineRef.current.style("opacity", 0);
-        tooltipGroupRef.current.style("opacity", 0);
-        dotRef.current.style("opacity", 0);
+        hideToolTip();
         setActiveIndex(null);
       })
       .on("mousemove", (event) => {
@@ -207,6 +210,9 @@ const LinePlot = ({
     if (activeIndex !== null) {
       showToolTip();
       updateTooltip(activeIndex);
+    }
+    else {
+      hideToolTip();
     }
   }, [data, activeIndex]);
 


### PR DESCRIPTION
Because the tooltip drawing on the lineplots happened in the same use effect as drawing the rest of the plot data, which doesn't change unless the units change, multiple line plots selected would result in a lagging tooltip.

This separate the tooltip drawing into a second use effect so that the data for each plot is drawn once and only the tooltip elements are redrawn on mouse events.