### PR TITLE
allowing conditions to be set

### DIFF
--- a/src/components/Conditions/ConditionsList.jsx
+++ b/src/components/Conditions/ConditionsList.jsx
@@ -2,13 +2,14 @@ import React from "react";
 import { connect } from "react-redux";
 import AddCondition from "./AddCondition";
 import { getConditions, getUserDefinedRatesIds } from "../../redux/selectors";
+import { getMechanism } from "../../redux/selectors";
 
 const ConditionsList = (props) => {
   return (
     <div className="card mb-4 p-0 shadow-sm">
       <div className="card-header d-flex justify-content-between">
         <h4 className="my-0">{props.schema.label}</h4>
-        {props.schema.allowAddRemove && props.possibleReactions.length > 0 ? (
+        {props.schema.allowAddRemove && props.remaining_unused > 0 ? (
           <AddCondition schema={props.schema} />
         ) : null}
       </div>
@@ -38,11 +39,22 @@ const ConditionsList = (props) => {
 const mapStateToProps = (state, ownProps) => {
   const { schema } = ownProps;
   const conditions = getConditions(state, schema);
-  const reactionIds = conditions.map((condition) => condition.reactionId);
-  const possibleReactions = getUserDefinedRatesIds(state).filter(
-    (reaction) => !reactionIds.includes(reaction.id),
-  );
-  return { conditions, possibleReactions };
+
+  // keep track of how many conditions can still be added
+  let remaining_unused = 0;
+
+  if (schema.classKey === "initial_species_concentrations") {
+    const mechanism = getMechanism(state);
+    // -1 below because M is always a species in the gas phase
+    // but you cannot set its concentration
+    remaining_unused = mechanism.gasSpecies.length - 1 - conditions.length;
+  }
+  else if (schema.classKey === "initial_reactions") {
+    const reactionIds = conditions.map((condition) => condition.reactionId);
+    const possibleReactions = getUserDefinedRatesIds(state)
+    remaining_unused = possibleReactions.length - reactionIds.length;
+  }
+  return { conditions, remaining_unused };
 };
 
 export default connect(mapStateToProps)(ConditionsList);

--- a/src/components/Conditions/SpeciesCondition.jsx
+++ b/src/components/Conditions/SpeciesCondition.jsx
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import Dropdown from "react-bootstrap/Dropdown";
 import { addCondition } from "../../redux/actions";
 import RemoveCondition from "./RemoveCondition";
-import { getCondition, getVariableSpeciesNames } from "../../redux/selectors";
+import { getConditions, getVariableSpeciesNames } from "../../redux/selectors";
 
 const SpeciesCondition = (props) => {
   const condition = props.condition;
@@ -29,18 +29,18 @@ const SpeciesCondition = (props) => {
           <Dropdown.Menu>
             {schema.allowAddRemove
               ? props.speciesNames.map((value) => {
-                  return (
-                    <Dropdown.Item
-                      href="#"
-                      key={value}
-                      onClick={(e) => {
-                        handleUpdate("name", e.target.innerHTML);
-                      }}
-                    >
-                      {value}
-                    </Dropdown.Item>
-                  );
-                })
+                return (
+                  <Dropdown.Item
+                    href="#"
+                    key={value}
+                    onClick={(e) => {
+                      handleUpdate("name", e.target.innerHTML);
+                    }}
+                  >
+                    {value}
+                  </Dropdown.Item>
+                );
+              })
               : condition.name}
           </Dropdown.Menu>
         </Dropdown>
@@ -89,8 +89,13 @@ const SpeciesCondition = (props) => {
 };
 
 const mapStateToProps = (state, ownProps) => {
+  const existingConditions = getConditions(state, ownProps.schema);
+  const possibleNames = getVariableSpeciesNames(state);
+  const speciesNames = possibleNames.filter(
+    (name) => !existingConditions.find((condition) => condition.name === name)
+  );
   return {
-    speciesNames: getVariableSpeciesNames(state),
+    speciesNames: speciesNames,
   };
 };
 


### PR DESCRIPTION
#204 introduced a bug where you couldn't poke the plus button to add a condition. I didn't realize that the conditions for reactions and initial concentrations was shared then.

This counts the number of possible reactions or species concentrations that can be added and shows the add button when there are more than zero. It also only shows species in the dropdown that have not already been added.