### PR TITLE
sets default units for evolving conditions files that don't have them

### DIFF
--- a/src/controllers/transformers.jsx
+++ b/src/controllers/transformers.jsx
@@ -403,13 +403,25 @@ function extract_conditions_from_example(config, mechanism) {
         let table_name = "";
         if (type === "LOSS" || name.substring(0, 5) === "LOSS_") {
           table_name = `PHOT.LOSS_${name.replace(/LOSS_/, "")}.s-1`;
+          units = units || "s-1";
         } else if (type === "EMIS" || name.substring(0, 5) === "EMIS_") {
           table_name = `PHOT.EMIS_${name.replace(/EMIS_/, "")}.s-1`;
+          units = units || "s-1";
         } else if (type === "PHOT") {
           table_name = `PHOT.${name}.s-1`;
+          units = units || "s-1";
         } else {
           table_name = key;
         }
+        if (type === "ENV" && units === undefined) {
+          if (name === "temperature") {
+            units = "K";
+          }
+          if (name === "pressure") {
+            units = "Pa";
+          }
+        }
+          
         evolving.values.push({
           name: `${type}.${name} [${units}]`,
           tableName: table_name,


### PR DESCRIPTION
Found out in #257 that evolving conditions files that are old don't have the units in the header column. I added all of the units in [a PR that updates those files](https://github.com/NCAR/musicbox_curriculum_exercises/pull/3), but I also added default units with this

closes #257
closes #243