### PR TITLE
bundle python

### DIFF
--- a/app/main/main.js
+++ b/app/main/main.js
@@ -55,7 +55,7 @@ ipcMain.handle("run-python", async (event, script, args) => {
   const configFileDir = path.join(
     appDataPath,
     "previous_results",
-    `mechanism-${Date.now()}`,
+    `mechanism-${Date.now()}`
   );
 
   await fs.promises.mkdir(configFileDir, { recursive: true });
@@ -75,16 +75,34 @@ ipcMain.handle("run-python", async (event, script, args) => {
       app.getAppPath(),
       "src",
       "scripts",
-      "print_config.py",
+      "print_config.py"
     );
   }
 
-  const command = `python ${scriptPath} ${configFilePath} ${configFileDir}`;
+  function findPython() {
+    const possibilities = [
+      // In packaged app
+      path.join(process.resourcesPath, "python", "bin", "python"),
+      // In development
+      path.join(__dirname, "python", "bin", "python"),
+    ];
+    for (const path of possibilities) {
+      if (fs.existsSync(path)) {
+        return path;
+      }
+    }
+    console.log("Could not find python3, checked", possibilities);
+    app.quit();
+  }
+
+  const pythonPath = findPython();
+
+  const command = `${pythonPath} ${scriptPath} ${tempFilePath}`;
   console.log(`Full command: ${command}`);
 
   try {
     return new Promise((resolve, reject) => {
-      const python = spawn("python", [
+      const python = spawn(pythonPath, [
         scriptPath,
         configFilePath,
         configFileDir,
@@ -139,7 +157,7 @@ ipcMain.handle("load-example", async (event, example) => {
       app.getAppPath(),
       "src",
       "examples",
-      exampleFile,
+      exampleFile
     );
   }
 
@@ -207,7 +225,7 @@ ipcMain.handle("load-previous-config", async (event, dir) => {
       try {
         const configFileContent = fs.readFileSync(
           path.join(filePath, configFile),
-          "utf-8",
+          "utf-8"
         );
         let config = JSON.parse(configFileContent);
 

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,5 +1,7 @@
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
+import fs from "fs";
+import path from "path";
 
 export default {
   packagerConfig: {
@@ -13,6 +15,7 @@ export default {
       "./src/examples/CHAPMAN.json",
       "./src/examples/FLOW_TUBE.json",
       "./src/examples/FULL_GAS_PHASE.json",
+      "./python/",
     ],
   },
   rebuildConfig: {},
@@ -51,4 +54,22 @@ export default {
       [FuseV1Options.OnlyLoadAppFromAsar]: true,
     }),
   ],
+  hooks: {
+    prePackage: async () => {
+      const pythonBinDir = path.join("python");
+      console.log(`${pythonBinDir}`);
+      if (fs.existsSync(pythonBinDir)) {
+        const files = fs.readdirSync(pythonBinDir);
+        for (const file of files) {
+          const filePath = path.join(pythonBinDir, file);
+          const stats = fs.statSync(filePath);
+          if (!stats.isDirectory() && stats.nlink > 1) {
+            const realPath = fs.realpathSync(filePath);
+            fs.unlinkSync(filePath);
+            fs.copyFileSync(realPath, filePath);
+          }
+        }
+      }
+    },
+  },
 };


### PR DESCRIPTION
in progress work for bundling python using python-build-standalone

what works:
- building and running on Windows with the bundled

what doesn't work:
- packaging electron-packager thinks the hardlinks present in the macOS python-build-standalone package link to somewhere outside of the electron application
    - was able to at least get it to build on macOS by running a prePackage hook that deletes all hardlinks and copies the linked file (obviously not a long-term solution)

blockers:
- macOS:
  - run-python ipc fails (issue #____)
  