### PR TITLE
Fix for the issue of Objects are not valid as a React child #315

### DIFF
--- a/src/components/Mechanism/AerosolMechanismTab.jsx
+++ b/src/components/Mechanism/AerosolMechanismTab.jsx
@@ -39,6 +39,11 @@ function AerosolMechanismTab({ type, tabIndexMap, setActiveTab }) {
     [2, "Representations"],
   ]);
 
+  const handleActiveSubTab = (index) => {
+    setDetails({});
+    setActiveSubTab(index);
+  };
+
   return (
     <>
       <InstructionsComponent
@@ -55,7 +60,7 @@ function AerosolMechanismTab({ type, tabIndexMap, setActiveTab }) {
               key={index}
               variant={activeSubTab === index ? "primary" : "secondary"}
               className="mr-2"
-              onClick={() => setActiveSubTab(index)}
+              onClick={() => handleActiveSubTab(index)}
             >
               {subTab}
             </Button>


### PR DESCRIPTION
Setting details to empty object when transfering to new tab