### PR TITLE
adding new units

### DIFF
--- a/src/components/Conditions/InitialConditionsTab.jsx
+++ b/src/components/Conditions/InitialConditionsTab.jsx
@@ -18,7 +18,7 @@ const initialConditionsSchema = {
     nameLabel: "Species name",
     classKey: "initial_species_concentrations",
     allowAddRemove: true,
-    units: ["mol m-3", "mol cm-3", "molec m-3", "molec cm-3"],
+    units: ["mol mol-1", "ppth", "ppm", "ppb", "ppt", "mol m-3", "mol cm-3", "molec m-3", "molec cm-3"],
   },
   environmentalConditions: {
     label: "Environmental Conditions",


### PR DESCRIPTION
Closes #346 

The input value should be 1 on the plots because the input value is 1/air density for species A. We indeed see that

<img width="1728" alt="Screenshot 2024-10-04 at 12 05 44 PM" src="https://github.com/user-attachments/assets/315b931e-9bcb-4791-882b-1988c1e71bdd">
<img width="1728" alt="Screenshot 2024-10-04 at 12 05 36 PM" src="https://github.com/user-attachments/assets/66be1e1d-1e0e-4204-b4d0-9742bc8964bd">
