### PR TITLE
Add workflow to close stale issues

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -17,7 +17,7 @@ jobs:
           days-before-stale: 180 # Mark as stale after 180 days of inactivity
           days-before-close: 14  # Close issue if no activity after 14 days of being stale
           days-before-pr-close: -1
-          stale-label: stale
+          stale-issue-label: Stale         # This setting defines the label that will be applied to issues that are considered stale
           exempt-issue-labels: Low Priority
           stale-issue-message: >
             This issue has been automatically marked as stale due to inactivity.

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,25 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  issues:
+    types: [opened, edited, labeled, unlabeled]
+
+jobs:
+  close-stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale issues
+        uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: 7
+          stale-label: stale
+          exempt-issue-labels: pinned
+          stale-issue-message: >
+            This issue has been automatically marked as stale due to inactivity.
+            If it remains inactive for another 7 days, it will be closed.
+          close-issue-message: >
+            This issue is now closed due to prolonged inactivity.

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -24,3 +24,5 @@ jobs:
             If it remains inactive for another 7 days, it will be closed.
           close-issue-message: >
             This issue is now closed due to prolonged inactivity.
+          operations-per-run: 30           # This setting specifies the maximum number of operations (such as marking issues as stale or closing them) that the action will perform in a single run
+          close-issue-reason: not_planned  # This setting specifies the reason that will be given when closing stale issues

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -21,7 +21,7 @@ jobs:
           exempt-issue-labels: Low Priority
           stale-issue-message: >
             This issue has been automatically marked as stale due to inactivity.
-            If it remains inactive for another 7 days, it will be closed.
+            If it remains inactive for another 14 days, it will be closed.
           close-issue-message: >
             This issue is now closed due to prolonged inactivity.
           operations-per-run: 30           # This setting specifies the maximum number of operations (such as marking issues as stale or closing them) that the action will perform in a single run

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -14,8 +14,9 @@ jobs:
         uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 30
-          days-before-close: 7
+          days-before-stale: 180 # Mark as stale after 180 days of inactivity
+          days-before-close: 14  # Close issue if no activity after 14 days of being stale
+          days-before-pr-close: -1
           stale-label: stale
           exempt-issue-labels: pinned
           stale-issue-message: >

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -18,7 +18,7 @@ jobs:
           days-before-close: 14  # Close issue if no activity after 14 days of being stale
           days-before-pr-close: -1
           stale-label: stale
-          exempt-issue-labels: pinned
+          exempt-issue-labels: Low Priority
           stale-issue-message: >
             This issue has been automatically marked as stale due to inactivity.
             If it remains inactive for another 7 days, it will be closed.


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to automatically manage stale issues. It labels issues as stale after 30 days of inactivity and closes them if they remain stale for an additional 7 days. Pinned issues are exempt from this process. 

Closees #360